### PR TITLE
EVM bytecode security analysis result

### DIFF
--- a/contracts/Vault.sol
+++ b/contracts/Vault.sol
@@ -221,7 +221,7 @@ contract Vault is Initializable, UUPSUpgradeable, AuthInitializable {
         tokenDebts[asset] = tokenDebts[asset] - amount;
         GCD(gcd).burn(user, amount);
 
-        return debts[asset][user];
+        return debts[asset][user]; //!
     }
 
     /**

--- a/contracts/helpers/TransferHelper.sol
+++ b/contracts/helpers/TransferHelper.sol
@@ -26,7 +26,7 @@ library TransferHelper {
     }
 
     function safeTransferETH(address to, uint value) internal {
-        (bool success,) = to.call{value:value}(new bytes(0));
+        (bool success,) = to.call{value:value}(new bytes(0)); //!
         require(success, 'TransferHelper: ETH_TRANSFER_FAILED');
     }
 }

--- a/contracts/test-helpers/StETHPriceFeed.sol
+++ b/contracts/test-helpers/StETHPriceFeed.sol
@@ -37,7 +37,7 @@ contract StETHPriceFeed {
 
   function _current_price() internal view returns (uint256 pool_price, bool has_changed_unsafely, uint256 oracle_price) {
     pool_price = IStableSwap(curve_pool_address).get_dy(CURVE_STETH_INDEX, CURVE_ETH_INDEX, 10**18);
-    //oracle_price = IStableSwapStateOracle(stable_swap_oracle_address).stethPrice();
+    oracle_price = IStableSwapStateOracle(stable_swap_oracle_address).stethPrice(); //!
     has_changed_unsafely = _percentage_diff(pool_price, oracle_price) > max_safe_price_difference;
   }
 

--- a/contracts/test-helpers/StETHPriceFeed.sol
+++ b/contracts/test-helpers/StETHPriceFeed.sol
@@ -37,7 +37,7 @@ contract StETHPriceFeed {
 
   function _current_price() internal view returns (uint256 pool_price, bool has_changed_unsafely, uint256 oracle_price) {
     pool_price = IStableSwap(curve_pool_address).get_dy(CURVE_STETH_INDEX, CURVE_ETH_INDEX, 10**18);
-    oracle_price = IStableSwapStateOracle(stable_swap_oracle_address).stethPrice();
+    //oracle_price = IStableSwapStateOracle(stable_swap_oracle_address).stethPrice();
     has_changed_unsafely = _percentage_diff(pool_price, oracle_price) > max_safe_price_difference;
   }
 

--- a/scripts/deployGCD.js
+++ b/scripts/deployGCD.js
@@ -1,3 +1,5 @@
+// execution error
+
 const hre = require("hardhat");
 const { upgrades } = require("hardhat");
 const { ethers } = hre;

--- a/scripts/deployTokens.js
+++ b/scripts/deployTokens.js
@@ -1,3 +1,5 @@
+// execution error
+
 const hre = require("hardhat");
 const { ethers } = hre;
 


### PR DESCRIPTION
**[Update StETHPriceFeed.sol]:**
Multiple calls are executed in the same transaction.
This call is executed following another call within the same transaction. It is possible that the call never gets executed if a prior call fails permanently. This might be caused intentionally by a malicious callee. If possible, refactor the code such that each transaction only executes one external call or make sure that all callees can be trusted (i.e. they’re part of your own codebase).
In file: /tmp/gcd-protocol-master/contracts/test-helpers/StETHPriceFeed.sol:40

**[Update Vault.sol]:**
Read of persistent state following external call
The contract account state is accessed after an external call to a fixed address. To prevent reentrancy issues, consider accessing the state only before the call, especially if the callee is untrusted. Alternatively, a reentrancy lock can be used to prevent untrusted callees from re-entering the contract in an intermediate state.
In file: /tmp/gcd-protocol-master/contracts/Vault.sol:224

**[Update TransferHelper.sol]:**
A call to a user-supplied address is executed.
An external message call to an address specified by the caller is executed. Note that the callee account might contain arbitrary code and could re-enter any function within this contract. Reentering the contract in an intermediate state may lead to unexpected behaviour. Make sure that no state modifications are executed after this call and/or reentrancy guards are in place.
In file: /tmp/gcd-protocol-master/contracts/helpers/TransferHelper.sol:29

**[Update deployGCD,js & Update deployTokens.js]:**
Executing the JavaScript files mentioned above always results in the following HeadersTimeoutError Message:

> gcd-contracts@0.0.1 deploy:gcd:gton
> hardhat run --network gton ./scripts/deployGCD.js

Account :  0x50038D2BbC9bAC0419D9346050739ceFa737934a
Account balance:  1000000000000000000000
HeadersTimeoutError: Headers Timeout Error
    at Timeout.onParserTimeout [as _onTimeout] (C:\Users\Daniel\Documents\HRW\GTON\gcd-protocol-master 2\gcd-protocol-master\node_modules\undici\lib\client.js:893:26)
    at listOnTimeout (internal/timers.js:556:17)
    at processTimers (internal/timers.js:497:7) {
  code: 'UND_ERR_HEADERS_TIMEOUT'
}

Deploying GCD & tokens on other testnets - Ropsten for example - does actually work. The Smart Contracts compile without errors, but still I'm not able to use the deployment scripts on the GTON testnet.